### PR TITLE
Fix Content Security Policy Errors Loading Github Profile Photos

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -19,6 +19,7 @@ backend:
     # host: 127.0.0.1
   csp:
     connect-src: ["'self'", 'http:', 'https:']
+    img-src: ["'self'", 'data:', 'https:']
     # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
     # Default Helmet Content-Security-Policy values can be removed by setting the key to false
   cors:


### PR DESCRIPTION
Back stage is getting csp errors trying to load github profile photos from https://avatars.githubusercontent.com. This is my attempt at fixing this.