### PR TITLE
Update Java Template Scaffolder so that project owner can only be selected from a list of valid github teams

### DIFF
--- a/packages/backend/templates/terra-java-project/template.yaml
+++ b/packages/backend/templates/terra-java-project/template.yaml
@@ -67,8 +67,12 @@ spec:
           title: Team
           type: string
           description: Github user or team that will own the repository
+          ui:field: OwnerPicker
           ui:autofocus: true
           ui:placeholder: github-team
+          ui:options:
+            catalogFilter:
+              kind: [Group]
 
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.

--- a/packages/backend/templates/terra-java-project/template.yaml
+++ b/packages/backend/templates/terra-java-project/template.yaml
@@ -66,7 +66,7 @@ spec:
         owner:
           title: Team
           type: string
-          description: Github user or team that will own the repository
+          description: Github team that will own the repository
           ui:field: OwnerPicker
           ui:autofocus: true
           ui:placeholder: github-team


### PR DESCRIPTION
Applies @choover-broad's feedback that scaffolding a new repo fails when the supplied owner is a github user rather than a team.

This changes the form so the owner must be selected from a list of valid github teams in one of our orgs rather than just a general text field

![Screenshot 2023-08-24 at 4 33 27 PM](https://github.com/broadinstitute/dsp-backstage/assets/60187023/3d5f01f5-551b-4a72-9965-58ac20cfccca)
