### PR TITLE
DDO-3092 Input Validation for Project Slug

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -54,12 +54,12 @@
     "react-router": "^6.3.0",
     "react-router-dom": "^6.3.0",
     "react-use": "^17.2.4",
+    "@rjsf/core": "^5.12.1",
     "zod": "^3.22.2"
   },
   "devDependencies": {
     "@backstage/catalog-client": "^1.4.3",
     "@backstage/test-utils": "^1.4.1",
-    "@rjsf/core": "^5.12.1",
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -38,6 +38,7 @@ import { SignInPage } from '@backstage/core-components';
 
 import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
 import { GithubTeamPickerExtension } from './scaffolder/GithubTeamPicker/GithubTeamPicker';
+import { ValidateSlugExtension } from './scaffolder/ValidateSlug';
 
 const app = createApp({
   apis,
@@ -96,6 +97,7 @@ const routes = (
     <Route path="/create" element={<ScaffolderPage />}>
       <ScaffolderFieldExtensions>
         <GithubTeamPickerExtension />
+        <ValidateSlugExtension />
       </ScaffolderFieldExtensions>
     </Route>
     <Route path="/api-docs" element={<ApiExplorerPage />} />

--- a/packages/app/src/scaffolder/ValidateSlug/ValidateSlugExtension.tsx
+++ b/packages/app/src/scaffolder/ValidateSlug/ValidateSlugExtension.tsx
@@ -1,41 +1,45 @@
-import React from "react";
-import { FieldProps, FieldValidation } from "@rjsf/core";
-import { FormControl, FormHelperText, Input, InputLabel } from "@material-ui/core";
-
+import React from 'react';
+import { FieldProps, FieldValidation } from '@rjsf/core';
+import {
+  FormControl,
+  FormHelperText,
+  Input,
+  InputLabel,
+} from '@material-ui/core';
 
 export const ValidateSlug = ({
-    onChange,
-    rawErrors,
-    required,
-    formData,
+  onChange,
+  rawErrors,
+  required,
+  formData,
 }: FieldProps<string>) => {
-    return (
-        <FormControl
-          margin="normal"
-          required={required}
-          error={rawErrors?.length > 0 && !formData}
-        >
-          <InputLabel htmlFor="validateSlug">Project Slug</InputLabel>
-          <Input
-            id="validateSlug"
-            aria-describedby="entityName"
-            onChange={e => onChange(e.target?.value)}
-          />
-          <FormHelperText id="entityName">
-            Project slug must be lowercase and contain only letters and numbers, no spaces or dashes
-          </FormHelperText>
-        </FormControl>
-    );
+  return (
+    <FormControl
+      margin="normal"
+      required={required}
+      error={rawErrors?.length > 0 && !formData}
+    >
+      <InputLabel htmlFor="validateSlug">Project Slug</InputLabel>
+      <Input
+        id="validateSlug"
+        aria-describedby="entityName"
+        onChange={e => onChange(e.target?.value)}
+      />
+      <FormHelperText id="entityName">
+        Project slug must be lowercase and contain only letters and numbers, no
+        spaces or dashes
+      </FormHelperText>
+    </FormControl>
+  );
 };
 
-export const slugValidation = (
-    value: string,
-    validation: FieldValidation
-) => {
-    // Regex check for single word with no spaces or dashes
-    const validSlug = /^[a-z0-9]+$/g.test(value);
+export const slugValidation = (value: string, validation: FieldValidation) => {
+  // Regex check for single word with no spaces or dashes
+  const validSlug = /^[a-z0-9]+$/g.test(value);
 
-    if (!validSlug) {
-        validation.addError("Project slug must be lowercase and contain only letters and numbers, no spaces or dashes");
-    }
+  if (!validSlug) {
+    validation.addError(
+      'Project slug must be lowercase and contain only letters and numbers, no spaces or dashes',
+    );
+  }
 };

--- a/packages/app/src/scaffolder/ValidateSlug/ValidateSlugExtension.tsx
+++ b/packages/app/src/scaffolder/ValidateSlug/ValidateSlugExtension.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { FieldProps, FieldValidation } from "@rjsf/core";
+import { FormControl, FormHelperText, Input, InputLabel } from "@material-ui/core";
+
+
+export const ValidateSlug = ({
+    onChange,
+    rawErrors,
+    required,
+    formData,
+}: FieldProps<string>) => {
+    return (
+        <FormControl
+          margin="normal"
+          required={required}
+          error={rawErrors?.length > 0 && !formData}
+        >
+          <InputLabel htmlFor="validateSlug">Project Slug</InputLabel>
+          <Input
+            id="validateSlug"
+            aria-describedby="entityName"
+            onChange={e => onChange(e.target?.value)}
+          />
+          <FormHelperText id="entityName">
+            Project slug must be lowercase and contain only letters and numbers, no spaces or dashes
+          </FormHelperText>
+        </FormControl>
+    );
+};
+
+export const slugValidation = (
+    value: string,
+    validation: FieldValidation
+) => {
+    // Regex check for single word with no spaces or dashes
+    const validSlug = /^[a-z0-9]+$/g.test(value);
+
+    if (!validSlug) {
+        validation.addError("Project slug must be lowercase and contain only letters and numbers, no spaces or dashes");
+    }
+};

--- a/packages/app/src/scaffolder/ValidateSlug/index.ts
+++ b/packages/app/src/scaffolder/ValidateSlug/index.ts
@@ -1,0 +1,11 @@
+import { scaffolderPlugin } from "@backstage/plugin-scaffolder";
+import { createScaffolderFieldExtension } from "@backstage/plugin-scaffolder-react";
+import { ValidateSlug, slugValidation } from "./ValidateSlugExtension";
+
+export const ValidateSlugExtension = scaffolderPlugin.provide(
+    createScaffolderFieldExtension({
+        name: "ValidateSlug",
+        component: ValidateSlug,
+        validation: slugValidation,
+    }),
+);

--- a/packages/app/src/scaffolder/ValidateSlug/index.ts
+++ b/packages/app/src/scaffolder/ValidateSlug/index.ts
@@ -1,11 +1,11 @@
-import { scaffolderPlugin } from "@backstage/plugin-scaffolder";
-import { createScaffolderFieldExtension } from "@backstage/plugin-scaffolder-react";
-import { ValidateSlug, slugValidation } from "./ValidateSlugExtension";
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import { ValidateSlug, slugValidation } from './ValidateSlugExtension';
 
 export const ValidateSlugExtension = scaffolderPlugin.provide(
-    createScaffolderFieldExtension({
-        name: "ValidateSlug",
-        component: ValidateSlug,
-        validation: slugValidation,
-    }),
+  createScaffolderFieldExtension({
+    name: 'ValidateSlug',
+    component: ValidateSlug,
+    validation: slugValidation,
+  }),
 );

--- a/templates/terra-java-project/template.yaml
+++ b/templates/terra-java-project/template.yaml
@@ -33,9 +33,7 @@ spec:
           title: Project Slug
           type: string
           description: A short one word name for the project used in infrastructure representations. NO HYPHENS!
-          ui:placholder: shortname
-          ui:options:
-            rows: 5
+          ui:field: ValidateSlug
         visibility:
           title: Repo Visibility
           type: string


### PR DESCRIPTION

![Screenshot 2023-08-30 at 12 01 40 PM](https://github.com/broadinstitute/dsp-backstage/assets/60187023/8483e244-e358-4a34-a2ad-7ddb75579f0d)
We need a single word shortname for all software projects that we can use in infrastructure representations.

This validation enforces that every new project submit a project slug that is a single word with no spaces or hyphens. This will be used for helm chart names etc..