### PR TITLE
DDO-3065 Multi Stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
-.git
-.yarn/cache
-.yarn/install-state.gz
+dist-types
 node_modules
-packages/*/src
+packages/*/dist
 packages/*/node_modules
-plugins
-*.local.yaml
+plugins/*/dist
+plugins/*/node_modules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,18 +84,6 @@ jobs:
           RELEASE_BRANCHES: ${{ github.event.repository.default_branch }}
           WITH_V: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Pre build commands
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "16.x"
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: run tsc
-        run: yarn tsc
-      - name: build backend
-        run: yarn build:backend
       # Build images
       - name: Construct docker image name and tag
         id: image-name
@@ -112,7 +100,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: packages/backend/Dockerfile
+          file: Dockerfile
           push: false
           load: true
           tags: |

--- a/.github/workflows/dependabot-build.yaml
+++ b/.github/workflows/dependabot-build.yaml
@@ -16,7 +16,8 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v3
         with:
-          file: packages/backend/Dockerfile
+          context: .
+          file: Dockerfile
           push: false
           load: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+# Stage 1 - Create yarn install skeleton
+FROM node:16-bullseye-slim as packages
+
+WORKDIR /app
+
+COPY packages packages
+
+# COPY plugins plugins
+
+RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
+
+# Stage 2 - Install dependencies and build packages
+
+FROM node:16-bullseye-slim as build
+
+# Install isolate vm dependencies needed by the scaffolder backend
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3 g++ build-essential && \
+    yarn config set python /usr/bin/python3
+
+USER node
+WORKDIR /app
+
+COPY --from=packages --chown=node:node /app .
+
+COPY --chown=node:node . .
+# Don't install cypress
+ENV CYPRESS_INSTALL_BINARY=0
+RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
+    yarn install --frozen-lockfile
+
+RUN yarn tsc
+
+RUN yarn --cwd packages/backend build
+
+RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
+    && tar xzf packages/backend/dist/skeleton.tar.gz -C packages/backend/dist/skeleton \
+    && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
+
+# Stage 3 - Build the actual backend and install prod depedencies
+
+FROM node:16-bullseye-slim
+
+# Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3 g++ build-essential && \
+    yarn config set python /usr/bin/python3
+
+# From here on we use the least-privileged `node` user to run the backend.
+USER node
+
+# This should create the app dir as `node`.
+# If it is instead created as `root` then the `tar` command below will fail: `can't create directory 'packages/': Permission denied`.
+# If this occurs, then ensure BuildKit is enabled (`DOCKER_BUILDKIT=1`) so the app dir is correctly created as `node`.
+WORKDIR /app
+
+# Copy the install dependencies from the build stage and context
+COPY --from=build --chown=node:node /app/yarn.lock /app/package.json /app/packages/backend/dist/skeleton/ ./
+
+RUN yarn install --frozen-lockfile --network-timeout 600000
+
+# Copy the built packages from the build stage
+COPY --from=build --chown=node:node /app/packages/backend/dist/bundle/ ./
+
+# Copy any other files that we need at runtime
+COPY --chown=node:node app-config.yaml ./
+
+# This switches many Node.js dependencies to production mode.
+ENV NODE_ENV production
+
+CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.production.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY --from=build --chown=node:node /app/packages/backend/dist/bundle/ ./
 
 # Copy any other files that we need at runtime
-COPY --chown=node:node app-config.yaml ./
+COPY --chown=node:node app-config*.yaml ./
 
 # This switches many Node.js dependencies to production mode.
 ENV NODE_ENV production

--- a/templates/terra-java-project/template.yaml
+++ b/templates/terra-java-project/template.yaml
@@ -102,7 +102,7 @@ spec:
           - access: admin
             team: databiosphere/broad-devops
           - access: write
-            team: databiosphere/BroadWrite
+            team: databiosphere/broadwrite
           - access: admin
             user: dsp-atlantis
           - access: admin


### PR DESCRIPTION
Converts backstage to build using the multi stage docker file best practice. I have tested this by deploying the images built from this PR to backstage-dev, everything seems to be working. This also introduces a variety of different caching stages which will hopefully speed up the builds. Just over the course of iterating on this PR I've managed to cut the build time in half from 12 minutes to 6 minutes.