### PR TITLE
Fix Application of Writer Permissions in Template

### DIFF
--- a/templates/terra-java-project/template.yaml
+++ b/templates/terra-java-project/template.yaml
@@ -101,7 +101,7 @@ spec:
         collaborators:
           - access: admin
             team: databiosphere/broad-devops
-          - access: write
+          - access: push
             team: databiosphere/broadwrite
           - access: admin
             user: dsp-atlantis


### PR DESCRIPTION
apparently the access field needs to be `push` rather than `write` to grant writer access on a repo. Had to go poking around the backstage codebase to find this :(

Tested by running the scaffolder locally and verifying the resulting repo properly grants writer permissions to the desired team