### PR TITLE
Fix User identity Mapping

### DIFF
--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -37,16 +37,16 @@ export default async function createPlugin(
       //   https://backstage.io/docs/auth/identity-resolver
       github: providers.github.create({
         signIn: {
-          resolver(_, ctx) {
-            const userRef = 'user:default/guest'; // Must be a full entity reference
-            return ctx.issueToken({
-              claims: {
-                sub: userRef, // The user's own identity
-                ent: [userRef], // A list of identities that the user claims ownership through
-              },
-            });
-          },
-          // resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
+          // resolver(_, ctx) {
+          //   const userRef = 'user:default/guest'; // Must be a full entity reference
+          //   return ctx.issueToken({
+          //     claims: {
+          //       sub: userRef, // The user's own identity
+          //       ent: [userRef], // A list of identities that the user claims ownership through
+          //     },
+          //   });
+          // },
+          resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
         },
       }),
     },

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -37,15 +37,6 @@ export default async function createPlugin(
       //   https://backstage.io/docs/auth/identity-resolver
       github: providers.github.create({
         signIn: {
-          // resolver(_, ctx) {
-          //   const userRef = 'user:default/guest'; // Must be a full entity reference
-          //   return ctx.issueToken({
-          //     claims: {
-          //       sub: userRef, // The user's own identity
-          //       ent: [userRef], // A list of identities that the user claims ownership through
-          //     },
-          //   });
-          // },
           resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
         },
       }),


### PR DESCRIPTION
I noticed that while backstage uses github as an IDP for sign in under the hood it was mapping every signed in user to a `user:guest` identity. Obviously we don't want that, This will now properly map each user to their identity in github when they log in.