### PR TITLE
Dependabot PR build is failing to find Dockerfile

### DIFF
--- a/.github/workflows/dependabot-build.yaml
+++ b/.github/workflows/dependabot-build.yaml
@@ -16,8 +16,6 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v3
         with:
-          context: .
-          file: Dockerfile
           push: false
           load: true
           tags: |


### PR DESCRIPTION
Since refactoring to the multistage build Docker file, dependabot build has been failing with can't find `Dockerfile` errors.