### PR TITLE
Add Terra System Definition to Backstage

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -41,6 +41,10 @@ catalog:
       target: https://github.com/broadinstitute/dsp-backstage/blob/main/templates/terra-java-project/template.yaml
       rules:
         - allow: [Template]
+    - type: url
+      target: https://github.com/broadinstitute/dsp-backstage/blob/main/templates/systems/terra.yaml
+      rules:
+        - allow: [System]
 auth:
   environment: prod
   providers:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -91,6 +91,8 @@ catalog:
   locations:
     - type: file
       target: ../../templates/terra-java-project/template.yaml
+    - type: file
+      target: ../../templates/systems/terra.yaml
   providers:
     github:
       broadinstituteProvider:

--- a/templates/systems/terra.yaml
+++ b/templates/systems/terra.yaml
@@ -3,7 +3,7 @@ kind: System
 metadata:
   name: terra
   description: |
-    Terra is a cloud-native platform for biomedical researchers to access data, run analysis tools, and collaborate. 
+    Terra is a cloud-native platform for biomedical researchers to access data, run analysis tools, and collaborate.
   tags:
     - dsp
     - terra

--- a/templates/systems/terra.yaml
+++ b/templates/systems/terra.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: terra
+  description: |
+    Terra is a cloud-native platform for biomedical researchers to access data, run analysis tools, and collaborate. 
+  tags:
+    - dsp
+    - terra
+    - java
+spec:
+  owner: broadwrite


### PR DESCRIPTION
This adds a `System` definition for Terra. This is so that an app can declare itself a part of the terra system and clicking on the Terra link in backstage won't just result in a page that says entity not found.