### PR TITLE
Fact collectors should not run every minute to avoid throttling

### DIFF
--- a/soundcheck/github-facts-collectors.yaml
+++ b/soundcheck/github-facts-collectors.yaml
@@ -1,6 +1,6 @@
 ---
 frequency:
-  cron: '* * * * *'
+  cron: '0 * * * *'
 filter:
   kind: 'Component'
 cache:


### PR DESCRIPTION
Had these frequencies set to every minute for testing, that should not be the case for prod.