### PR TITLE
Github based Soundcheck Fact Collectors should only check hourly in prod envs to avoid throttling

### DIFF
--- a/soundcheck/github-facts-collectors.yaml
+++ b/soundcheck/github-facts-collectors.yaml
@@ -1,6 +1,6 @@
 ---
 frequency:
-  cron: '* * * * *'
+  cron: '0 * * * *'
 filter:
   kind: 'Component'
 cache:

--- a/soundcheck/scm-facts-collectors.yaml
+++ b/soundcheck/scm-facts-collectors.yaml
@@ -1,6 +1,6 @@
 ---
 frequency:
-  cron: '* * * * *' # Defines a schedule for when the facts defined in this file should be collected
+  cron: '0 * * * *' # Defines a schedule for when the facts defined in this file should be collected
   # This is optional and if omitted, facts will only be collected on demand.
 filter: # A filter specifying which entities to collect the specified facts for
   kind: 'Component'


### PR DESCRIPTION
For actual deployments sound check fact collectors should only crawl github repos hourly not every minute to avoid throttling. I had it set the other way for testing purposes.