### PR TITLE
Fix for Button bug in scaffolder form submission

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -10,7 +10,8 @@ import {
   CatalogImportPage,
   catalogImportPlugin,
 } from '@backstage/plugin-catalog-import';
-import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { LegacyScaffolderPage } from '@backstage/plugin-scaffolder/alpha';
 import { orgPlugin } from '@backstage/plugin-org';
 import { SearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage/plugin-tech-radar';
@@ -95,7 +96,7 @@ const routes = (
         <ReportIssue />
       </TechDocsAddons>
     </Route>
-    <Route path="/create" element={<ScaffolderPage />}>
+    <Route path="/create" element={<LegacyScaffolderPage />}>
       <ScaffolderFieldExtensions>
         <GithubTeamPickerExtension />
         <ValidateSlugExtension />

--- a/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.tsx
+++ b/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.tsx
@@ -23,7 +23,9 @@ import {
 
 export const GithubTeamPicker: (
   props: LegacyFieldExtensionComponentProps<any, any>,
-) => React.JSX.Element = (props: LegacyFieldExtensionComponentProps<any, any>) => {
+) => React.JSX.Element = (
+  props: LegacyFieldExtensionComponentProps<any, any>,
+) => {
   const {
     onChange,
     schema: { title = 'Github Team', description = 'Select a Github Team' },

--- a/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.tsx
+++ b/packages/app/src/scaffolder/GithubTeamPicker/GithubTeamPicker.tsx
@@ -17,13 +17,13 @@ import React, { useCallback, useEffect } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
 import {
-  createScaffolderFieldExtension,
-  FieldExtensionComponentProps,
-} from '@backstage/plugin-scaffolder-react';
+  createLegacyScaffolderFieldExtension,
+  LegacyFieldExtensionComponentProps,
+} from '@backstage/plugin-scaffolder-react/alpha';
 
 export const GithubTeamPicker: (
-  props: FieldExtensionComponentProps<any, any>,
-) => React.JSX.Element = (props: FieldExtensionComponentProps<any, any>) => {
+  props: LegacyFieldExtensionComponentProps<any, any>,
+) => React.JSX.Element = (props: LegacyFieldExtensionComponentProps<any, any>) => {
   const {
     onChange,
     schema: { title = 'Github Team', description = 'Select a Github Team' },
@@ -143,7 +143,7 @@ export const GithubTeamPicker: (
 };
 
 export const GithubTeamPickerExtension = scaffolderPlugin.provide(
-  createScaffolderFieldExtension({
+  createLegacyScaffolderFieldExtension({
     name: 'GithubTeamPicker',
     component: GithubTeamPicker,
   }),


### PR DESCRIPTION
Backstage seems to have updated some of it's ui libraries which broke a form submission button so that form fields would be cleared upon clicking a next button preventing the form from progressing to the next section. As a temp fix I reverted back to the "legacy" scaffolder UI experience where things work properly. Will investigating getting the new ui working properly separately.