### PR TITLE
Fix Soundcheck Dashboards dropping History after 24 hours

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -79,6 +79,12 @@ spotify:
   licenseKey: ${BACKSTAGE_LICENSE_KEY}
 
 soundcheck:
+  results:
+    history:
+      enable: true
+  certifications:
+    history:
+      enable: true
   programs:
     $include: ./soundcheck/soundcheck-programs.yaml
   checks:


### PR DESCRIPTION
Tiny config change to make the soundcheck dashboards not drop history after 24 hours. Tested on my local backstage setup.