### PR TITLE
[DDO-3456] Make cookie cutter reference qa.tfvars too

### DIFF
--- a/templates/terra-java-project/template.yaml
+++ b/templates/terra-java-project/template.yaml
@@ -182,7 +182,7 @@ spec:
                   "autoplan": {
                     "enabled": true
                   }
-                },
+                }
               ]
             } |
           )

--- a/templates/terra-java-project/template.yaml
+++ b/templates/terra-java-project/template.yaml
@@ -182,7 +182,7 @@ spec:
                   "autoplan": {
                     "enabled": true
                   }
-                }
+                },
               ]
             } |
           )
@@ -287,6 +287,16 @@ spec:
                   "dir": "${{parameters.projectSlug}}",
                   "workflow": "./tfvars/$WORKSPACE.tfvars",
                   "workspace": "dev",
+                  "terraform_version": "v1.5.7",
+                  "autoplan": {
+                    "enabled": true
+                  }
+                },
+                {
+                  "name": "${{parameters.projectSlug}}-qa",
+                  "dir": "${{parameters.projectSlug}}",
+                  "workflow": "./tfvars/$WORKSPACE.tfvars",
+                  "workspace": "qa",
                   "terraform_version": "v1.5.7",
                   "autoplan": {
                     "enabled": true


### PR DESCRIPTION
Requires https://github.com/broadinstitute/terraform-ap-deployments/pull/1358

Makes it so the cookie cutter will reference the qa.tfvars that future cookie-cutter-ings will create

## Testing

No clue tbh

## Risk

Low?