### PR TITLE
Add Support for deriving OwnerRef From Github Codeowners

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -1,4 +1,4 @@
-import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
+import { CatalogBuilder, CodeOwnersProcessor } from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
 import {
   GithubEntityProvider,
@@ -45,6 +45,10 @@ export default async function createPlugin(
     }),
   );
   builder.addProcessor(new ScaffolderEntitiesProcessor());
+  builder.addProcessor(CodeOwnersProcessor.fromConfig(env.config, {
+    logger: env.logger,
+    reader: env.reader,
+  }));
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();
   return router;

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -1,4 +1,7 @@
-import { CatalogBuilder, CodeOwnersProcessor } from '@backstage/plugin-catalog-backend';
+import {
+  CatalogBuilder,
+  CodeOwnersProcessor,
+} from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
 import {
   GithubEntityProvider,
@@ -45,10 +48,12 @@ export default async function createPlugin(
     }),
   );
   builder.addProcessor(new ScaffolderEntitiesProcessor());
-  builder.addProcessor(CodeOwnersProcessor.fromConfig(env.config, {
-    logger: env.logger,
-    reader: env.reader,
-  }));
+  builder.addProcessor(
+    CodeOwnersProcessor.fromConfig(env.config, {
+      logger: env.logger,
+      reader: env.reader,
+    }),
+  );
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();
   return router;


### PR DESCRIPTION
Adds support for deriving the owner of a backstage entity from a `CODEOWNERS` file in the repo if one exists.

Tested by provisioning a new repo but leaving `spec.owner` out of the foundation.yaml file and verifying that an owner still gets assigned to the service in backstage.

cc: @cpate4 