### PR TITLE
DDO-3686 Add Validation for Repo Name to backstage scaffolder

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -40,6 +40,7 @@ import { SignInPage } from '@backstage/core-components';
 import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
 import { GithubTeamPickerExtension } from './scaffolder/GithubTeamPicker/GithubTeamPicker';
 import { ValidateSlugExtension } from './scaffolder/ValidateSlug';
+import { ValidateRepoExtension } from './scaffolder/ValidateRepo';
 import { SoundcheckRoutingPage } from '@spotify/backstage-plugin-soundcheck';
 
 const app = createApp({
@@ -100,6 +101,7 @@ const routes = (
       <ScaffolderFieldExtensions>
         <GithubTeamPickerExtension />
         <ValidateSlugExtension />
+        <ValidateRepoExtension />
       </ScaffolderFieldExtensions>
     </Route>
     <Route path="/api-docs" element={<ApiExplorerPage />} />

--- a/packages/app/src/scaffolder/ValidateRepo/ValidateRepoExtension.tsx
+++ b/packages/app/src/scaffolder/ValidateRepo/ValidateRepoExtension.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { FieldProps, FieldValidation } from "@rjsf/utils";
+import { FormControl, FormHelperText, Input, InputLabel } from "@material-ui/core";
+
+export const ValidateRepo = ({
+  onChange,
+  rawErrors,
+  required,
+  formData,
+}: FieldProps<string>) => {
+  return (
+    <FormControl
+      margin="normal"
+      required={required}
+      error={rawErrors !== undefined && rawErrors.length > 0 && !formData}
+    >
+      <InputLabel htmlFor="validateRepo">Project Repository Name</InputLabel>
+      <Input
+        id="validateRepo"
+        aria-describedby="entityName"
+        onChange={(e) => onChange(e.target?.value)}
+      />
+      <FormHelperText id="entityName">
+        Project repository name must be lowercase and contain only letters, numbers, and hyphens
+      </FormHelperText>   
+    </FormControl>
+  );
+}
+
+export const repoValidation = (value: string, validation: FieldValidation) => {
+  // Regex check for single word with no spaces or dashes
+  const validRepo = /^[a-z0-9-]+$/g.test(value);
+
+  if (!validRepo) {
+    validation.addError(
+      "Project repository name must be lowercase and contain only letters, numbers, and hyphens",
+    );
+  }
+};

--- a/packages/app/src/scaffolder/ValidateRepo/ValidateRepoExtension.tsx
+++ b/packages/app/src/scaffolder/ValidateRepo/ValidateRepoExtension.tsx
@@ -1,6 +1,11 @@
-import React from "react";
-import { FieldProps, FieldValidation } from "@rjsf/utils";
-import { FormControl, FormHelperText, Input, InputLabel } from "@material-ui/core";
+import React from 'react';
+import { FieldProps, FieldValidation } from '@rjsf/utils';
+import {
+  FormControl,
+  FormHelperText,
+  Input,
+  InputLabel,
+} from '@material-ui/core';
 
 export const ValidateRepo = ({
   onChange,
@@ -18,14 +23,15 @@ export const ValidateRepo = ({
       <Input
         id="validateRepo"
         aria-describedby="entityName"
-        onChange={(e) => onChange(e.target?.value)}
+        onChange={e => onChange(e.target?.value)}
       />
       <FormHelperText id="entityName">
-        Project repository name must be lowercase and contain only letters, numbers, and hyphens
-      </FormHelperText>   
+        Project repository name must be lowercase and contain only letters,
+        numbers, and hyphens
+      </FormHelperText>
     </FormControl>
   );
-}
+};
 
 export const repoValidation = (value: string, validation: FieldValidation) => {
   // Regex check for single word with no spaces or dashes
@@ -33,7 +39,7 @@ export const repoValidation = (value: string, validation: FieldValidation) => {
 
   if (!validRepo) {
     validation.addError(
-      "Project repository name must be lowercase and contain only letters, numbers, and hyphens",
+      'Project repository name must be lowercase and contain only letters, numbers, and hyphens',
     );
   }
 };

--- a/packages/app/src/scaffolder/ValidateRepo/index.ts
+++ b/packages/app/src/scaffolder/ValidateRepo/index.ts
@@ -1,11 +1,11 @@
-import { scaffolderPlugin } from "@backstage/plugin-scaffolder";
-import { createScaffolderFieldExtension } from "@backstage/plugin-scaffolder-react";
-import { ValidateRepo, repoValidation } from "./ValidateRepoExtension";
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import { ValidateRepo, repoValidation } from './ValidateRepoExtension';
 
 export const ValidateRepoExtension = scaffolderPlugin.provide(
   createScaffolderFieldExtension({
-    name: "ValidateRepo",
+    name: 'ValidateRepo',
     component: ValidateRepo,
     validation: repoValidation,
-  })
+  }),
 );

--- a/packages/app/src/scaffolder/ValidateRepo/index.ts
+++ b/packages/app/src/scaffolder/ValidateRepo/index.ts
@@ -1,0 +1,11 @@
+import { scaffolderPlugin } from "@backstage/plugin-scaffolder";
+import { createScaffolderFieldExtension } from "@backstage/plugin-scaffolder-react";
+import { ValidateRepo, repoValidation } from "./ValidateRepoExtension";
+
+export const ValidateRepoExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: "ValidateRepo",
+    component: ValidateRepo,
+    validation: repoValidation,
+  })
+);

--- a/templates/terra-java-project/template.yaml
+++ b/templates/terra-java-project/template.yaml
@@ -29,6 +29,7 @@ spec:
           description: Unique name of the project. This will be used in the repository name and in the docker image name.
           ui:placholder: terra-javatemplate-service
           ui:autofocus: true
+          ui:field: ValidateRepo
         projectSlug:
           title: Project Slug
           type: string


### PR DESCRIPTION
A few users at this point have used spaces in the title of their repo name when provisioning a new service via backstage. Github will accept this but quietly replaces the spaces with `-` in the repo that ends up being created. Backstage has no knowledge of this replacement and subsequently tries to query github for the repo with spaces in the name and gets 404'd which causes templating to fail.

This addresses that by adding validation to the repository name field in the scaffolder that prevents the usage of spaces.

<img width="1361" alt="Screenshot 2024-05-15 at 8 35 52 AM" src="https://github.com/broadinstitute/dsp-backstage/assets/60187023/a71161b7-d6ce-4415-b238-17d25e260d3c">
