### PR TITLE
Bump TF versions

### DIFF
--- a/templates/terra-java-project/template.yaml
+++ b/templates/terra-java-project/template.yaml
@@ -179,7 +179,7 @@ spec:
                   "dir": "github",
                   "workflow": "./tfvars/$WORKSPACE.tfvars",
                   "workspace": $repoName,
-                  "terraform_version": "v1.1.1",
+                  "terraform_version": "v1.8.1",
                   "autoplan": {
                     "enabled": false,
                     "when_modified": ["modules", "'*.tf'", "tfvars/" & $repoName & ".tfvars"]
@@ -289,7 +289,7 @@ spec:
                   "dir": "${{parameters.projectSlug}}",
                   "workflow": "./tfvars/$WORKSPACE.tfvars",
                   "workspace": "dev",
-                  "terraform_version": "v1.5.7",
+                  "terraform_version": "v1.8.1",
                   "autoplan": {
                     "enabled": true
                   }
@@ -299,7 +299,7 @@ spec:
                   "dir": "${{parameters.projectSlug}}",
                   "workflow": "./tfvars/$WORKSPACE.tfvars",
                   "workspace": "qa",
-                  "terraform_version": "v1.5.7",
+                  "terraform_version": "v1.8.1",
                   "autoplan": {
                     "enabled": true
                   }


### PR DESCRIPTION
Bumps the TF versions for new service PRs since recent TF fixed a bug that would show a diff on certain resources when none were actually present, which could lead to something like a GSM secret version being recreated when the data matched.